### PR TITLE
Adding the call to SeekDevice::close() inside SeekCam::close()

### DIFF
--- a/src/SeekCam.cpp
+++ b/src/SeekCam.cpp
@@ -63,6 +63,7 @@ void SeekCam::close()
         m_dev.request_set(DeviceCommand::SET_OPERATION_MODE, data);
         m_dev.request_set(DeviceCommand::SET_OPERATION_MODE, data);
         m_dev.request_set(DeviceCommand::SET_OPERATION_MODE, data);
+        m_dev.close();
     }
     m_is_opened = false;
 }


### PR DESCRIPTION
The libusb interface will be released and closed. Now the camera can be open again after close without the error 'Error: SeekDevice already opened'